### PR TITLE
Add uv supply-chain guardrail with exclude-newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ dev = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.uv]
+exclude-newer = "1 week"

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "2026-03-19T07:13:58.333957Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "aiocache"
 version = "0.12.3"
@@ -441,7 +445,7 @@ cli = [
 
 [[package]]
 name = "mcp-monumenten"
-version = "1.1.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "dotenv" },


### PR DESCRIPTION
Add uv configuration to exclude very recent package releases and refresh lockfiles to improve dependency safety and reproducibility across local development and CI.